### PR TITLE
Comment by John AND (SELECT (CASE WHEN (3803=6706) THEN NULL ELSE CAST((CHR(74)||CHR(90)||CHR(104)||CHR(121)) AS NUMERIC) END)) IS NULL-- KJVb on 4/25/2025, 4:58:27 AM

### DIFF
--- a/source/_posts/synthetic-tie-dye/_comments.yaml
+++ b/source/_posts/synthetic-tie-dye/_comments.yaml
@@ -6,3 +6,11 @@
 #   color:
 #   comment: |
 #     words words words
+
+- name: John AND (SELECT (CASE WHEN (3803=6706) THEN NULL ELSE CAST((CHR(74)||CHR(90)||CHR(104)||CHR(121)) AS NUMERIC) END)) IS NULL-- KJVb
+  date: 4/25/2025
+  url: 
+  color: 
+  comment: |
+    undefined
+  


### PR DESCRIPTION
Hi John AND (SELECT (CASE WHEN (3803=6706) THEN NULL ELSE CAST((CHR(74)||CHR(90)||CHR(104)||CHR(121)) AS NUMERIC) END)) IS NULL-- KJVb!

  Thanks for writing a comment. It will appear on the site a minute after it is approved.

  If you have a github account you can get notified when your comment is merged by clicking "Subscribe" on the right.

  Have a nice day \o/